### PR TITLE
simplify cbor::decoder by removing CBORObject

### DIFF
--- a/src/cbor/decoder.rs
+++ b/src/cbor/decoder.rs
@@ -5,7 +5,6 @@ use std::string::String;
 #[derive(Debug)]
 pub struct DecoderCursor {
     pub cursor: Cursor<Vec<u8>>,
-    pub decoded: CBORObject,
 }
 
 impl DecoderCursor {
@@ -45,17 +44,6 @@ impl DecoderCursor {
         Ok(val)
     }
 
-    /// Read an integer and add it to the decoded values.
-    fn parse_int(&mut self, tag: bool) -> Result<(), &'static str> {
-        let val = self.read_int().unwrap();
-        if tag {
-            self.decoded.values.push(CBORType::Tag(val));
-        } else {
-            self.decoded.values.push(CBORType::Integer(val));
-        }
-        Ok(())
-    }
-
     fn read_signed_int(&mut self) -> Result<CBORType, &'static str> {
         let uint = self.read_int().unwrap();
         if uint > i64::max_value() as u64 {
@@ -63,13 +51,6 @@ impl DecoderCursor {
         }
         let result: i64 = -1 - uint as i64;
         Ok(CBORType::SignedInteger(result))
-    }
-
-    /// Read an integer and add it to the decoded values.
-    fn parse_signed_int(&mut self) -> Result<(), &'static str> {
-        let val = self.read_signed_int().unwrap();
-        self.decoded.values.push(val);
-        Ok(())
     }
 
     /// Read an array of data items and return it.
@@ -83,13 +64,6 @@ impl DecoderCursor {
             array.push(self.decode_item().unwrap());
         }
         Ok(CBORType::Array(array))
-    }
-
-    /// Read an array of data items.
-    fn parse_array(&mut self) -> Result<(), &'static str> {
-        let array = self.read_array().unwrap();
-        self.decoded.values.push(array);
-        Ok(())
     }
 
     /// Read a byte string and return it as hex string.
@@ -108,13 +82,6 @@ impl DecoderCursor {
             return Err("Couldn't read enough data for this byte string");
         }
         Ok(CBORType::Bytes(byte_string))
-    }
-
-    /// Read a byte string and return it as hex string.
-    fn parse_byte_string(&mut self) -> Result<(), &'static str> {
-        let bytes = self.read_byte_string().unwrap();
-        self.decoded.values.push(bytes);
-        Ok(())
     }
 
     /// Read a map.
@@ -136,15 +103,8 @@ impl DecoderCursor {
         Ok(CBORType::Map(map))
     }
 
-    /// Read a map.
-    fn parse_map(&mut self) -> Result<(), &'static str> {
-        let map = self.read_map().unwrap();
-        self.decoded.values.push(map);
-        Ok(())
-    }
-
     /// Decodes the next item in DecoderCursor.
-    fn decode_item(&mut self) -> Result<CBORType, &'static str> {
+    pub fn decode_item(&mut self) -> Result<CBORType, &'static str> {
         let pos = self.cursor.position() as usize;
         let major_type = self.cursor.get_ref()[pos] >> 5;
         match major_type {
@@ -153,7 +113,8 @@ impl DecoderCursor {
             2 => return Ok(self.read_byte_string().unwrap()),
             4 => return Ok(self.read_array().unwrap()),
             5 => return Ok(self.read_map().unwrap()),
-            6 => return Ok(CBORType::Tag(self.read_int().unwrap())),
+            6 => return Ok(CBORType::Tag(self.read_int().unwrap(),
+                                         Box::new(self.decode_item().unwrap()))),
             _ => return Err("Malformed first byte"),
         }
     }
@@ -173,85 +134,18 @@ pub struct CBORMap {
 pub enum CBORType {
     Integer(u64),
     SignedInteger(i64),
-    Tag(u64),
+    Tag(u64, Box<CBORType>),
     Bytes(Vec<u8>),
     String(String),
     Array(Vec<CBORType>),
     Map(Vec<CBORMap>),
 }
 
-/// XXX: I really have to rethink the Tag value.
-impl From<u64> for CBORType {
-    fn from(x: u64) -> Self {
-        CBORType::Integer(x)
-    }
-}
-
-impl From<i64> for CBORType {
-    fn from(x: i64) -> Self {
-        CBORType::SignedInteger(x)
-    }
-}
-
-impl From<Vec<u8>> for CBORType {
-    fn from(x: Vec<u8>) -> Self {
-        CBORType::Bytes(x)
-    }
-}
-
-impl From<String> for CBORType {
-    fn from(x: String) -> Self {
-        CBORType::String(x)
-    }
-}
-
-impl From<Vec<CBORType>> for CBORType {
-    fn from(x: Vec<CBORType>) -> Self {
-        CBORType::Array(x)
-    }
-}
-
-impl From<Vec<CBORMap>> for CBORType {
-    fn from(x: Vec<CBORMap>) -> Self {
-        CBORType::Map(x)
-    }
-}
-
-#[derive(Debug)]
-pub struct CBORObject {
-    pub values: Vec<CBORType>,
-}
-
-impl PartialEq for CBORObject {
-    fn eq(&self, other: &CBORObject) -> bool {
-        if self.values.len() != other.values.len() {
-            return false;
-        }
-        self.values.eq(&other.values)
-    }
-}
-
-/// Decodes the next item in DecoderCursor.
-pub fn decode_item(decoder_cursor: &mut DecoderCursor) -> Result<(), &'static str> {
-    let major_type = decoder_cursor.cursor.get_ref()[decoder_cursor.cursor.position() as usize] >>
-        5;
-    match major_type {
-        0 => decoder_cursor.parse_int(false),
-        1 => decoder_cursor.parse_signed_int(),
-        2 => decoder_cursor.parse_byte_string(),
-        4 => decoder_cursor.parse_array(),
-        5 => decoder_cursor.parse_map(),
-        6 => decoder_cursor.parse_int(true),
-        _ => return Err("Malformed first byte"),
-    }
-}
-
 /// Read the CBOR structure in bytes and return it as a CBOR object.
-pub fn decode(bytes: Vec<u8>) -> Result<CBORObject, &'static str> {
+pub fn decode(bytes: Vec<u8>) -> Result<CBORType, &'static str> {
     let mut decoder_cursor = DecoderCursor {
         cursor: Cursor::new(bytes),
-        decoded: CBORObject { values: Vec::new() },
     };
-    decode_item(&mut decoder_cursor).unwrap();
-    Ok(decoder_cursor.decoded)
+    decoder_cursor.decode_item()
+    // TODO: check cursor at end?
 }

--- a/src/cose/decoder.rs
+++ b/src/cose/decoder.rs
@@ -1,5 +1,4 @@
 use cbor::decoder::*;
-use std::io::Cursor;
 
 #[derive(Debug)]
 pub enum CoseType {
@@ -40,112 +39,146 @@ macro_rules! unpack {
     )
 }
 
-pub fn decode_signature(bytes: Vec<u8>, payload: &[u8]) -> Result<CoseSignatures, &'static str> {
-    let mut decoder_cursor = DecoderCursor {
-        cursor: Cursor::new(bytes),
-        decoded: CBORObject { values: Vec::new() },
-    };
-    let mut result = CoseSignatures { values: Vec::new() };
-    decode_item(&mut decoder_cursor).unwrap();
-    // This has to be as COSE_Sign object.
-    if decoder_cursor.decoded.values.len() != 1 {
-        return Err("This is not a COSE_Sign object 0");
-    }
-    let val = decoder_cursor.decoded.values[0].clone();
-    match val {
-        CBORType::Tag(val) => {
-            if val != CoseType::COSESign as u64 {
-                return Err("This is not a COSE_Sign object 1");
-            }
-        }
-        _ => return Err("This is not a COSE_Sign object 2"),
-    }
+/// COSE_Sign = [
+///     Headers,
+///     payload : bstr / nil,
+///     signatures : [+ COSE_Signature]
+/// ]
+///
+/// Headers = (
+///     protected : empty_or_serialized_map,
+///     unprotected : header_map
+/// )
+///
+/// This syntax is a little unintuitive. Taken together, the two previous definitions essentially
+/// mean:
+///
+/// COSE_Sign = [
+///     protected : empty_or_serialized_map,
+///     unprotected : header_map
+///     payload : bstr / nil,
+///     signatures : [+ COSE_Signature]
+/// ]
+///
+/// (COSE_Sign is an array. The first element is an empty or serialized map (in our case, it is
+/// never expected to be empty). The second element is a map (it is expected to be empty. The third
+/// element is a bstr or nil (it is expected to be nil). The fourth element is an array of
+/// COSE_Signature.)
+///
+/// COSE_Signature =  [
+///     Headers,
+///     signature : bstr
+/// ]
+///
+/// but again, unpacking this:
+///
+/// COSE_Signature =  [
+///     protected : empty_or_serialized_map,
+///     unprotected : header_map
+///     signature : bstr
+/// ]
 
-    // Now we know we have a COSE_Sign object.
-    // The remaining data item has to be an array.
-    decode_item(&mut decoder_cursor).unwrap();
-    if decoder_cursor.decoded.values.len() < 2 {
-        return Err("This is not a valid COSE signature object 0.");
+pub fn decode_signature(bytes: Vec<u8>, payload: &[u8]) -> Result<CoseSignatures, &'static str> {
+    // This has to be a COSE_Sign object, which is a tagged array.
+    let tagged_cose_sign = decode(bytes)?;
+    let cose_sign_array = match tagged_cose_sign {
+        CBORType::Tag(tag, cose_sign) => {
+            if tag != CoseType::COSESign as u64 {
+                return Err("This is not a COSE_Sign object 0");
+            }
+            match *cose_sign {
+                CBORType::Array(values) => values,
+                _ => return Err("This is not a COSE_Sign object 1"),
+            }
+        },
+        _ => return Err("This is not a COSE_Sign object 2"),
+    };
+    if cose_sign_array.len() != 4 {
+        return Err("This is not a valid COSE signature object 3.");
     }
-    let tmp = &decoder_cursor.decoded.values[1];
-    let cose_object = unpack!(Array, tmp);
-    if cose_object.len() < 4 {
-        return Err("This is not a valid COSE signature object 2.");
-    }
-    let tmp = &cose_object[3];
-    let signature_items = unpack!(Array, tmp);
+    let signatures = &cose_sign_array[3];
+    let signatures = unpack!(Array, signatures);
 
     // Take the first signature.
-    if signature_items.len() < 1 {
-        return Err(
-            "This is not a valid COSE Signature. Couldn't find a signature object.",
-        );
+    if signatures.len() < 1 {
+        return Err("This is not a valid COSE Signature. Couldn't find a signature object.");
     }
-    let tmp = &signature_items[0];
-    let signature_item = unpack!(Array, tmp);
-    if signature_item.len() < 3 {
+    let cose_signature = &signatures[0];
+    let cose_signature = unpack!(Array, cose_signature);
+    if cose_signature.len() != 3 {
         return Err("This is not a valid COSE Signature. Too short.");
     }
-    let tmp = &signature_item[0];
-    let protected_signature_header = unpack!(Bytes, tmp);
+    let protected_signature_header_bytes = &cose_signature[0];
+    let protected_signature_header_bytes = unpack!(Bytes, protected_signature_header_bytes).clone();
 
     // Parse the protected signature header.
-    let mut header_cursor = DecoderCursor {
-        cursor: Cursor::new(protected_signature_header.clone()),
-        decoded: CBORObject { values: Vec::new() },
+    let protected_signature_header = decode(protected_signature_header_bytes.clone())?;
+    // This isn't quite right due to order... (it's a map)
+    let signature_algorithm = match protected_signature_header {
+        CBORType::Map(values) => {
+            if values.len() < 1 {
+                return Err("This is not a valid COSE signature object. Protected header is empty.");
+            }
+            values[0].clone()
+        },
+        _ => return Err("Invalid COSE signature object: protected header is not a map."),
     };
-    decode_item(&mut header_cursor).unwrap();
-    if header_cursor.decoded.values.len() < 1 {
-        return Err(
-            "This is not a valid COSE signature object. Protected header is empty.",
-        );
-    }
-
-    // Read the signature algorithm from the protected header.
-    let tmp = &header_cursor.decoded.values[0];
-    let signature_algorithm = unpack!(Map, tmp);
-    if signature_algorithm.len() < 1 || signature_algorithm[0].key != CBORType::Integer(1) {
-        // XXX: algorithm
-        return Err(
-            "This is not a valid COSE signature object. No algorithm given.",
-        );
-    }
-    if signature_algorithm[0].value != CBORType::SignedInteger(-7) {
-        // XXX: ES256
-        return Err(
-            "This is not a valid COSE signature object. Can't handle the algorithm.",
-        );
-    }
+    match signature_algorithm.key {
+        CBORType::Integer(val) => {
+            if val != 1 {
+                return Err("Invalid COSE signature: expected alg header key (1).");
+            }
+        },
+        _ => return Err("Invalid COSE signature: header key is not an integer."),
+    };
+    match signature_algorithm.value{
+        CBORType::SignedInteger(val) => {
+            if val != -7 {
+                return Err("Invalid COSE signature: expected ES256 (-7).");
+            }
+        },
+        _ => return Err("Invalid COSE signature: alg value is not a signed integer."),
+    };
     let signature_algorithm = CoseSignatureType::ES256;
 
     // Read the key ID from the unprotected header.
-    let tmp = &signature_item[1];
-    let key_id = unpack!(Map, tmp).clone();
-    if key_id.len() < 1 || key_id[0].key != CBORType::Integer(4) {
-        // XXX: kid
-        return Err(
-            "This is not a valid COSE signature object. No key ID given.",
-        );
-    }
-    let tmp = &key_id[0].value;
-    let key_id = unpack!(Bytes, tmp);
+    let unprotected_signature_header = &cose_signature[1];
+    let key_id = match unprotected_signature_header {
+        &CBORType::Map(ref value) => {
+            if value.len() < 1 {
+                return Err("Invalid COSE signature: unprotected header is empty.");
+            }
+            value[0].clone()
+        },
+        _ => return Err("Invalid COSE signature: unprotected header is not a map."),
+    };
+    match key_id.key {
+        CBORType::Integer(val) => {
+            if val != 4 {
+                return Err("Invalid COSE signature: expected kid header key (4).");
+            }
+        },
+        _ => return Err("Invalid COSE signature: header key is not an integer."),
+    };
+    let key_id_bytes = &key_id.value.clone();
+    let key_id = unpack!(Bytes, key_id_bytes);
 
     // Read the signature bytes.
-    let tmp = &signature_item[2];
-    let signature_bytes = unpack!(Bytes, tmp).clone();
+    let signature_bytes = &cose_signature[2];
+    let signature_bytes = unpack!(Bytes, signature_bytes).clone();
     let mut bytes_to_verify:Vec<u8> = Vec::new();
     // XXX: Use encoder for this.
     bytes_to_verify.push(0x69);
     bytes_to_verify.extend_from_slice(b"Signature");
     // XXX: Add protected body header when present.
     bytes_to_verify.push(0x40);
-    if protected_signature_header.len() > 23 {
+    if protected_signature_header_bytes.len() > 23 {
         // XXX: fix this.
         return Err("Sorry, this is not implemented for protected headers that are longer than 23.");
     }
-    let tmp:u8 = ((2 << 5) as u8) + protected_signature_header.len() as u8;
+    let tmp:u8 = ((2 << 5) as u8) + protected_signature_header_bytes.len() as u8;
     bytes_to_verify.push(tmp);
-    bytes_to_verify.append(&mut protected_signature_header.clone());
+    bytes_to_verify.append(&mut protected_signature_header_bytes.clone());
     bytes_to_verify.push(0x40);
     if payload.len() > 23 {
         // XXX: fix this.
@@ -164,6 +197,7 @@ pub fn decode_signature(bytes: Vec<u8>, payload: &[u8]) -> Result<CoseSignatures
         certs: Vec::new(),
         to_verify: bytes_to_verify,
     };
+    let mut result = CoseSignatures { values: Vec::new() };
     result.values.push(signature);
     Ok(result)
 }


### PR DESCRIPTION
I think CBORObject introduces an unnecessary level of indirection - every time we use it we really just want the underlying CBOR value.
Also, if I'm understanding the spec correctly, a tag consists of the tag itself and one CBOR value, so a tag by itself doesn't make much sense.