### PR TITLE
change CBOR to Cbor in type names to match rust style

### DIFF
--- a/src/cbor/decoder.rs
+++ b/src/cbor/decoder.rs
@@ -44,30 +44,30 @@ impl DecoderCursor {
         Ok(val)
     }
 
-    fn read_signed_int(&mut self) -> Result<CBORType, &'static str> {
+    fn read_signed_int(&mut self) -> Result<CborType, &'static str> {
         let uint = self.read_int().unwrap();
         if uint > i64::max_value() as u64 {
             return Err("Signed integer doesn't fit in a i64 (too large)");
         }
         let result: i64 = -1 - uint as i64;
-        Ok(CBORType::SignedInteger(result))
+        Ok(CborType::SignedInteger(result))
     }
 
     /// Read an array of data items and return it.
-    fn read_array(&mut self) -> Result<CBORType, &'static str> {
+    fn read_array(&mut self) -> Result<CborType, &'static str> {
         // Create a new array.
-        let mut array: Vec<CBORType> = Vec::new();
+        let mut array: Vec<CborType> = Vec::new();
         // Read the length of the array.
         let num_items = self.read_int().unwrap();
         // Decode each of the num_items data items.
         for _ in 0..num_items {
             array.push(self.decode_item().unwrap());
         }
-        Ok(CBORType::Array(array))
+        Ok(CborType::Array(array))
     }
 
     /// Read a byte string and return it as hex string.
-    fn read_byte_string(&mut self) -> Result<CBORType, &'static str> {
+    fn read_byte_string(&mut self) -> Result<CborType, &'static str> {
         let length = self.read_int().unwrap();
         if length > usize::max_value() as u64 {
             return Err("Byte array is too large to allocate.");
@@ -81,39 +81,39 @@ impl DecoderCursor {
         if self.cursor.read(&mut byte_string).unwrap() != length {
             return Err("Couldn't read enough data for this byte string");
         }
-        Ok(CBORType::Bytes(byte_string))
+        Ok(CborType::Bytes(byte_string))
     }
 
     /// Read a map.
-    fn read_map(&mut self) -> Result<CBORType, &'static str> {
+    fn read_map(&mut self) -> Result<CborType, &'static str> {
         // XXX: check for duplicate keys.
         let num_items = self.read_int().unwrap();
         // Create a new array.
-        let mut map: Vec<CBORMap> = Vec::new();
+        let mut map: Vec<CborMap> = Vec::new();
         // Decode each of the num_items (key, data item) pairs.
         for _ in 0..num_items {
             let key_val = self.decode_item().unwrap();
             let item_value = self.decode_item().unwrap();
-            let item = CBORMap {
+            let item = CborMap {
                 key: key_val,
                 value: item_value
             };
             map.push(item);
         }
-        Ok(CBORType::Map(map))
+        Ok(CborType::Map(map))
     }
 
     /// Decodes the next item in DecoderCursor.
-    pub fn decode_item(&mut self) -> Result<CBORType, &'static str> {
+    pub fn decode_item(&mut self) -> Result<CborType, &'static str> {
         let pos = self.cursor.position() as usize;
         let major_type = self.cursor.get_ref()[pos] >> 5;
         match major_type {
-            0 => return Ok(CBORType::Integer(self.read_int().unwrap())),
+            0 => return Ok(CborType::Integer(self.read_int().unwrap())),
             1 => return Ok(self.read_signed_int().unwrap()),
             2 => return Ok(self.read_byte_string().unwrap()),
             4 => return Ok(self.read_array().unwrap()),
             5 => return Ok(self.read_map().unwrap()),
-            6 => return Ok(CBORType::Tag(self.read_int().unwrap(),
+            6 => return Ok(CborType::Tag(self.read_int().unwrap(),
                                          Box::new(self.decode_item().unwrap()))),
             _ => return Err("Malformed first byte"),
         }
@@ -123,26 +123,26 @@ impl DecoderCursor {
 #[derive(Debug)]
 #[derive(Clone)]
 #[derive(PartialEq)]
-pub struct CBORMap {
-    pub key: CBORType,
-    pub value: CBORType,
+pub struct CborMap {
+    pub key: CborType,
+    pub value: CborType,
 }
 
 #[derive(Debug)]
 #[derive(Clone)]
 #[derive(PartialEq)]
-pub enum CBORType {
+pub enum CborType {
     Integer(u64),
     SignedInteger(i64),
-    Tag(u64, Box<CBORType>),
+    Tag(u64, Box<CborType>),
     Bytes(Vec<u8>),
     String(String),
-    Array(Vec<CBORType>),
-    Map(Vec<CBORMap>),
+    Array(Vec<CborType>),
+    Map(Vec<CborMap>),
 }
 
 /// Read the CBOR structure in bytes and return it as a CBOR object.
-pub fn decode(bytes: Vec<u8>) -> Result<CBORType, &'static str> {
+pub fn decode(bytes: Vec<u8>) -> Result<CborType, &'static str> {
     let mut decoder_cursor = DecoderCursor {
         cursor: Cursor::new(bytes),
     };

--- a/src/cbor/test_decoder.rs
+++ b/src/cbor/test_decoder.rs
@@ -3,7 +3,7 @@ use cbor::decoder::*;
 
 // First test all the basic types
 #[cfg(test)]
-fn test_decoder(bytes: Vec<u8>, expected: CBORType) {
+fn test_decoder(bytes: Vec<u8>, expected: CborType) {
     assert_eq!(decode(bytes).unwrap(), expected);
 }
 
@@ -11,14 +11,14 @@ fn test_decoder(bytes: Vec<u8>, expected: CBORType) {
 fn test_integer(bytes: Vec<u8>, expected: u64) {
     let decoded = decode(bytes).unwrap();
     match decoded {
-        CBORType::Integer(val) => assert_eq!(val, expected),
+        CborType::Integer(val) => assert_eq!(val, expected),
         _ => assert_eq!(1, 0),
     }
 }
 
 #[cfg(test)]
 fn test_integer_all(bytes: Vec<u8>, expected_value: u64) {
-    let expected = CBORType::Integer(expected_value);
+    let expected = CborType::Integer(expected_value);
     test_decoder(bytes.clone(), expected);
     test_integer(bytes, expected_value);
 }
@@ -60,10 +60,10 @@ fn test_integer_objects() {
 }
 
 #[cfg(test)]
-fn test_tag(bytes: Vec<u8>, expected_tag: u64, expected_value: CBORType) {
+fn test_tag(bytes: Vec<u8>, expected_tag: u64, expected_value: CborType) {
     let decoded = decode(bytes).unwrap();
     match decoded {
-        CBORType::Tag(tag, value) => {
+        CborType::Tag(tag, value) => {
             assert_eq!(expected_tag, tag);
             assert_eq!(expected_value, *value);
         },
@@ -75,8 +75,8 @@ fn test_tag(bytes: Vec<u8>, expected_tag: u64, expected_value: CBORType) {
 fn test_tagged_objects() {
     let bytes: Vec<u8> = vec![0xD2, 0x02];
     let expected_tag_value = 0x12;
-    let expected_value = CBORType::Integer(2);
-    let expected = CBORType::Tag(expected_tag_value, Box::new(expected_value.clone()));
+    let expected_value = CborType::Integer(2);
+    let expected = CborType::Tag(expected_tag_value, Box::new(expected_value.clone()));
     test_decoder(bytes.clone(), expected);
     test_tag(bytes, expected_tag_value, expected_value);
 }
@@ -85,43 +85,43 @@ fn test_tagged_objects() {
 fn test_arrays() {
     // []
     let bytes: Vec<u8> = vec![0x80];
-    let expected = CBORType::Array(vec![]);
+    let expected = CborType::Array(vec![]);
     test_decoder(bytes, expected);
 
     // [1, 2, 3]
     let bytes: Vec<u8> = vec![0x83, 0x01, 0x02, 0x03];
     let tmp = vec![
-        CBORType::Integer(1),
-        CBORType::Integer(2),
-        CBORType::Integer(3),
+        CborType::Integer(1),
+        CborType::Integer(2),
+        CborType::Integer(3),
     ];
-    let expected = CBORType::Array(tmp);
+    let expected = CborType::Array(tmp);
     test_decoder(bytes, expected);
 
     // [1, [2, 3], [4, 5]]
     let bytes: Vec<u8> = vec![0x83, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05];
-    let tmp1 = vec![CBORType::Integer(2), CBORType::Integer(3)];
-    let tmp2 = vec![CBORType::Integer(4), CBORType::Integer(5)];
+    let tmp1 = vec![CborType::Integer(2), CborType::Integer(3)];
+    let tmp2 = vec![CborType::Integer(4), CborType::Integer(5)];
     let tmp = vec![
-        CBORType::Integer(1),
-        CBORType::Array(tmp1),
-        CBORType::Array(tmp2),
+        CborType::Integer(1),
+        CborType::Array(tmp1),
+        CborType::Array(tmp2),
     ];
-    let expected = CBORType::Array(tmp);
+    let expected = CborType::Array(tmp);
     test_decoder(bytes, expected);
 
     // [1, [[[[1]]]], [1]]
     let bytes: Vec<u8> = vec![0x83, 0x01, 0x81, 0x81, 0x81, 0x81, 0x01, 0x81, 0x02];
     let tmp = vec![
-        CBORType::Integer(1),
-        CBORType::Array(vec![
-            CBORType::Array(vec![
-                CBORType::Array(vec![
-                    CBORType::Array(vec![
-                        CBORType::Integer(1)])])])]),
-        CBORType::Array(vec![CBORType::Integer(2)]),
+        CborType::Integer(1),
+        CborType::Array(vec![
+            CborType::Array(vec![
+                CborType::Array(vec![
+                    CborType::Array(vec![
+                        CborType::Integer(1)])])])]),
+        CborType::Array(vec![CborType::Integer(2)]),
     ];
-    let expected = CBORType::Array(tmp);
+    let expected = CborType::Array(tmp);
     test_decoder(bytes, expected);
 
     let bytes: Vec<u8> = vec![0x98, 0x1A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
@@ -132,89 +132,89 @@ fn test_arrays() {
     // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
     //  21, 22, 23, 24, 25, [[[[5]]], [1234567890]]]
     let tmp = vec![
-        CBORType::Integer(1),
-        CBORType::Integer(2),
-        CBORType::Integer(3),
-        CBORType::Integer(4),
-        CBORType::Integer(5),
-        CBORType::Integer(6),
-        CBORType::Integer(7),
-        CBORType::Integer(8),
-        CBORType::Integer(9),
-        CBORType::Integer(10),
-        CBORType::Integer(11),
-        CBORType::Integer(12),
-        CBORType::Integer(13),
-        CBORType::Integer(14),
-        CBORType::Integer(15),
-        CBORType::Integer(16),
-        CBORType::Integer(17),
-        CBORType::Integer(18),
-        CBORType::Integer(19),
-        CBORType::Integer(20),
-        CBORType::Integer(21),
-        CBORType::Integer(22),
-        CBORType::Integer(23),
-        CBORType::Integer(24),
-        CBORType::Integer(25),
-        CBORType::Array(vec![
-            CBORType::Array(vec![
-                CBORType::Array(vec![
-                    CBORType::Array(vec![
-                        CBORType::Integer(5)])])]),
-            CBORType::Array(vec![CBORType::Integer(1234567890)])])
+        CborType::Integer(1),
+        CborType::Integer(2),
+        CborType::Integer(3),
+        CborType::Integer(4),
+        CborType::Integer(5),
+        CborType::Integer(6),
+        CborType::Integer(7),
+        CborType::Integer(8),
+        CborType::Integer(9),
+        CborType::Integer(10),
+        CborType::Integer(11),
+        CborType::Integer(12),
+        CborType::Integer(13),
+        CborType::Integer(14),
+        CborType::Integer(15),
+        CborType::Integer(16),
+        CborType::Integer(17),
+        CborType::Integer(18),
+        CborType::Integer(19),
+        CborType::Integer(20),
+        CborType::Integer(21),
+        CborType::Integer(22),
+        CborType::Integer(23),
+        CborType::Integer(24),
+        CborType::Integer(25),
+        CborType::Array(vec![
+            CborType::Array(vec![
+                CborType::Array(vec![
+                    CborType::Array(vec![
+                        CborType::Integer(5)])])]),
+            CborType::Array(vec![CborType::Integer(1234567890)])])
     ];
-    let expected = CBORType::Array(tmp);
+    let expected = CborType::Array(tmp);
     test_decoder(bytes, expected);
 }
 
 #[test]
 fn test_signed_integer() {
     let bytes: Vec<u8> = vec![0x20];
-    let expected = CBORType::SignedInteger(-1);
+    let expected = CborType::SignedInteger(-1);
     test_decoder(bytes, expected);
 
     let bytes = vec![0x29];
-    let expected = CBORType::SignedInteger(-10);
+    let expected = CborType::SignedInteger(-10);
     test_decoder(bytes, expected);
 
     let bytes = vec![0x38, 0x63];
-    let expected = CBORType::SignedInteger(-100);
+    let expected = CborType::SignedInteger(-100);
     test_decoder(bytes, expected);
 
     let bytes = vec![0x39, 0x03, 0xe7];
-    let expected = CBORType::SignedInteger(-1000);
+    let expected = CborType::SignedInteger(-1000);
     test_decoder(bytes, expected);
 
     let bytes = vec![0x39, 0x27, 0x0F];
-    let expected = CBORType::SignedInteger(-10000);
+    let expected = CborType::SignedInteger(-10000);
     test_decoder(bytes, expected);
 
     let bytes = vec![0x3A, 0x00, 0x01, 0x86, 0x9F];
-    let expected = CBORType::SignedInteger(-100000);
+    let expected = CborType::SignedInteger(-100000);
     test_decoder(bytes, expected);
 
     let bytes = vec![0x3B, 0x00, 0x00, 0x00, 0xE8, 0xD4, 0xA5, 0x0F, 0xFF];
-    let expected = CBORType::SignedInteger(-1000000000000);
+    let expected = CborType::SignedInteger(-1000000000000);
     test_decoder(bytes, expected);
 }
 
 #[test]
 fn test_byte_strings() {
     let bytes: Vec<u8> = vec![0x40];
-    let expected = CBORType::Bytes(vec![]);
+    let expected = CborType::Bytes(vec![]);
     test_decoder(bytes, expected);
 
     // 01020304
     let bytes: Vec<u8> = vec![0x44, 0x01, 0x02, 0x03, 0x04];
-    let expected = CBORType::Bytes(vec![0x01, 0x02, 0x03, 0x04]);
+    let expected = CborType::Bytes(vec![0x01, 0x02, 0x03, 0x04]);
     test_decoder(bytes, expected);
 
     // 0102030405060708090A0B0C0D0E0F10203040506070
     let bytes: Vec<u8> = vec![0x56, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                               0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
                               0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70];
-    let expected = CBORType::Bytes(vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    let expected = CborType::Bytes(vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                                         0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
                                         0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70]);
     test_decoder(bytes, expected);
@@ -255,7 +255,7 @@ fn test_byte_strings() {
                               0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                               0xFF];
     let expected =
-        CBORType::Bytes(vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        CborType::Bytes(vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -297,23 +297,23 @@ fn test_byte_strings() {
 fn test_maps() {
     // {}
     let bytes: Vec<u8> = vec![0xa0];
-    let expected = CBORType::Map(vec![]);
+    let expected = CborType::Map(vec![]);
     test_decoder(bytes, expected);
 
     // {1: 2, 3: 4}
     let bytes: Vec<u8> = vec![0xa2, 0x01, 0x02, 0x03, 0x04];
     let expected =
-        CBORType::Map(vec![
-            CBORMap{key: CBORType::Integer(1), value: CBORType::Integer(2)},
-            CBORMap{key: CBORType::Integer(3), value: CBORType::Integer(4)}]);
+        CborType::Map(vec![
+            CborMap{key: CborType::Integer(1), value: CborType::Integer(2)},
+            CborMap{key: CborType::Integer(3), value: CborType::Integer(4)}]);
     test_decoder(bytes, expected);
 
     // {"a": 1, "b": [2, 3]}
     // let bytes: Vec<u8> = vec![0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03];
     // let expected =
-    //     CBORType::Map(vec![
-    //         CBORMap{key: CBORType::Integer(1), value: CBORType::Integer(2)},
-    //         CBORMap{key: CBORType::Integer(3), value: CBORType::Integer(4)}]);
+    //     CborType::Map(vec![
+    //         CborMap{key: CborType::Integer(1), value: CborType::Integer(2)},
+    //         CborMap{key: CborType::Integer(3), value: CborType::Integer(4)}]);
     // test_decoder(bytes, expected);
 
     // let bytes: Vec<u8> = vec![0x82, 0x61, 0x61, 0xa1, 0x61, 0x62, 0x61, 0x63];


### PR DESCRIPTION
This also changes the CoseType::COSESign enum to a constant
since that's really what we're using it as.

This fixes #4.