### PR TITLE
limit read_bytes input to 128MB

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,6 @@ fn main() {
     // the build will fail.
     let lib_dir = env::var("NSS_LIB_DIR");
     if lib_dir.is_ok() {
-        println!("cargo:rustc-link-search=native={}", lib_dir.unwrap());
+        println!("cargo:rustc-link-search={}", lib_dir.unwrap());
     }
 }

--- a/src/cbor/decoder.rs
+++ b/src/cbor/decoder.rs
@@ -2,7 +2,10 @@ use std::collections::BTreeMap;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 use cbor::cbor::{CborError, CborType};
 
-pub const MAX_ARRAY_SIZE: usize = 2147483648;
+// We limit the length of any cbor byte array to 128MiB. This is a somewhat
+// arbitrary limit that should work on all platforms and is large enough for
+// any benign data.
+pub const MAX_ARRAY_SIZE: usize = 134217728;
 
 /// Struct holding a cursor and additional information for decoding.
 #[derive(Debug)]
@@ -13,7 +16,6 @@ struct DecoderCursor {
 impl DecoderCursor {
     /// Read and return the given number of bytes from the cursor. Advances the cursor.
     fn read_bytes(&mut self, len: usize) -> Result<Vec<u8>, CborError> {
-        // We can not allocate more than 2GB.
         if len > MAX_ARRAY_SIZE {
             return Err(CborError::InputTooLarge);
         }

--- a/src/cbor/decoder.rs
+++ b/src/cbor/decoder.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 use cbor::cbor::{CborError, CborType};
 
+pub const MAX_ARRAY_SIZE: usize = 2147483648;
+
 /// Struct holding a cursor and additional information for decoding.
 #[derive(Debug)]
 struct DecoderCursor {
@@ -12,7 +14,7 @@ impl DecoderCursor {
     /// Read and return the given number of bytes from the cursor. Advances the cursor.
     fn read_bytes(&mut self, len: usize) -> Result<Vec<u8>, CborError> {
         // We can not allocate more than 2GB.
-        if len > 2147483648 {
+        if len > MAX_ARRAY_SIZE {
             return Err(CborError::InputTooLarge);
         }
         let mut buf: Vec<u8> = vec![0; len];

--- a/src/cbor/decoder.rs
+++ b/src/cbor/decoder.rs
@@ -11,6 +11,10 @@ struct DecoderCursor {
 impl DecoderCursor {
     /// Read and return the given number of bytes from the cursor. Advances the cursor.
     fn read_bytes(&mut self, len: usize) -> Result<Vec<u8>, CborError> {
+        // We can not allocate more than 2GB.
+        if len > 2147483648 {
+            return Err(CborError::InputTooLarge);
+        }
         let mut buf: Vec<u8> = vec![0; len];
         match self.cursor.read_exact(&mut buf) {
             Err(_) => return Err(CborError::TruncatedInput),

--- a/src/cbor/test_decoder.rs
+++ b/src/cbor/test_decoder.rs
@@ -371,15 +371,15 @@ fn test_signed_integer_too_large() {
 fn test_large_input() {
     let array = vec![0xFF; MAX_ARRAY_SIZE];
     let expected = CborType::Bytes(array.clone());
-    let mut bytes = vec![0x5A, 0x80, 0x00, 0x00, 0x00];
+    let mut bytes = vec![0x5A, 0x08, 0x00, 0x00, 0x00];
     bytes.extend_from_slice(&array);
     test_decoder(bytes, expected);
 }
 
 #[test]
 fn test_too_large_input() {
-    let array = vec![0xFF; MAX_ARRAY_SIZE+1];
-    let mut bytes = vec![0x5A, 0x80, 0x00, 0x00, 0x01];
+    let array = vec![0xFF; MAX_ARRAY_SIZE + 1];
+    let mut bytes = vec![0x5A, 0x08, 0x00, 0x00, 0x01];
     bytes.extend_from_slice(&array);
     test_decoder_error(bytes, CborError::InputTooLarge);
 }

--- a/src/cbor/test_decoder.rs
+++ b/src/cbor/test_decoder.rs
@@ -366,3 +366,20 @@ fn test_signed_integer_too_large() {
     let bytes = vec![0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
     test_decoder_error(bytes, CborError::InputValueOutOfRange);
 }
+
+#[test]
+fn test_large_input() {
+    let array = vec![0xFF; MAX_ARRAY_SIZE];
+    let expected = CborType::Bytes(array.clone());
+    let mut bytes = vec![0x5A, 0x80, 0x00, 0x00, 0x00];
+    bytes.extend_from_slice(&array);
+    test_decoder(bytes, expected);
+}
+
+#[test]
+fn test_too_large_input() {
+    let array = vec![0xFF; MAX_ARRAY_SIZE+1];
+    let mut bytes = vec![0x5A, 0x80, 0x00, 0x00, 0x01];
+    bytes.extend_from_slice(&array);
+    test_decoder_error(bytes, CborError::InputTooLarge);
+}


### PR DESCRIPTION
I started fuzzing a little and this was the first thing that blew up.
I'm not entirely sure what the limit is. But it seems you can't allocate more than 2GB here.