### PR TITLE
Add clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,8 @@ script:
 - |
   cargo build &&
   cargo test
+
+matrix:
+  include:
+    - rust: "nightly"
+      cargo build --features "clippy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ addons:
       - build-essential
       - libnss3-dev
 
+matrix:
+  include:
+    - rust: nightly
+      env: FEATURES=clippy
+
 script:
 # The NSS version in Ubuntu is too old. Get a newer one.
 - |
@@ -20,10 +25,5 @@ script:
   sudo dpkg -i libnspr4_4.16-1ubuntu1_amd64.deb
   sudo dpkg -i libnss3_3.32-1ubuntu3_amd64.deb
 - |
-  cargo build &&
+  cargo build --features "$FEATURES" &&
   cargo test
-
-matrix:
-  include:
-    - rust: "nightly"
-      cargo build --features "clippy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ build = "build.rs"
 
 [dependencies]
 scopeguard = "0.3"
+clippy = {version = "*", optional = true}
+
+[features]
+default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
 #[macro_use(defer)]
 extern crate scopeguard;
 


### PR DESCRIPTION
This adds clippy as optional dependency. You can run it locally with `rustup run nightly cargo build --features "clippy"` and it's run on travis (it doesn't error though).