### PR TITLE
Fix clippy warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,8 @@ script:
 - |
   cargo build &&
   cargo test
+
+matrix:
+  include:
+    - rust: "nightly"
+      cargo build --features "clippy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ addons:
       - build-essential
       - libnss3-dev
 
+matrix:
+  include:
+    - rust: nightly
+      env: FEATURES=clippy
+
 script:
 # The NSS version in Ubuntu is too old. Get a newer one.
 - |
@@ -20,10 +25,5 @@ script:
   sudo dpkg -i libnspr4_4.16-1ubuntu1_amd64.deb
   sudo dpkg -i libnss3_3.32-1ubuntu3_amd64.deb
 - |
-  cargo build &&
+  cargo build --features "$FEATURES" &&
   cargo test
-
-matrix:
-  include:
-    - rust: "nightly"
-      cargo build --features "clippy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ build = "build.rs"
 
 [dependencies]
 scopeguard = "0.3"
+clippy = {version = "*", optional = true}
+
+[features]
+default = []

--- a/src/cbor/decoder.rs
+++ b/src/cbor/decoder.rs
@@ -5,7 +5,7 @@ use cbor::cbor::{CborError, CborType};
 // We limit the length of any cbor byte array to 128MiB. This is a somewhat
 // arbitrary limit that should work on all platforms and is large enough for
 // any benign data.
-pub const MAX_ARRAY_SIZE: usize = 134217728;
+pub const MAX_ARRAY_SIZE: usize = 134_217_728;
 
 /// Struct holding a cursor and additional information for decoding.
 #[derive(Debug)]
@@ -80,8 +80,7 @@ impl DecoderCursor {
     /// Read a byte string and return it.
     fn read_byte_string(&mut self) -> Result<CborType, CborError> {
         let length = self.read_int()?;
-        let limit = usize::max_value() as u64;
-        if length > limit {
+        if length > MAX_ARRAY_SIZE as u64 {
             return Err(CborError::InputTooLarge);
         }
         let byte_string = self.read_bytes(length as usize)?;

--- a/src/cbor/serializer.rs
+++ b/src/cbor/serializer.rs
@@ -14,12 +14,12 @@ fn common_encode_unsigned(output: &mut Vec<u8>, tag: u8, value: u64) {
             output.push(shifted_tag | 24);
             output.push(value as u8);
         }
-        256...65535 => {
+        256...65_535 => {
             output.push(shifted_tag | 25);
             output.push((value >> 8) as u8);
             output.push((value & 255) as u8);
         }
-        65536...4294967295 => {
+        65_536...4_294_967_295 => {
             output.push(shifted_tag | 26);
             output.push((value >> 24) as u8);
             output.push(((value >> 16) & 255) as u8);
@@ -65,10 +65,10 @@ fn encode_bytes(output: &mut Vec<u8>, bstr: &[u8]) {
 }
 
 /// The major type is 3. The length is as with bstr. The UTF-8-encoded bytes of the string follow.
-fn encode_string(output: &mut Vec<u8>, tstr: &String) {
+fn encode_string(output: &mut Vec<u8>, tstr: &str) {
     let utf8_bytes = tstr.as_bytes();
     common_encode_unsigned(output, 3, utf8_bytes.len() as u64);
-    output.extend_from_slice(&utf8_bytes);
+    output.extend_from_slice(utf8_bytes);
 }
 
 /// The major type is 4. The number of items is encoded as with positive integers. Then follows the
@@ -94,7 +94,7 @@ fn encode_map(output: &mut Vec<u8>, map: &BTreeMap<CborType, CborType>) {
     }
 }
 
-fn encode_tag(output: &mut Vec<u8>, tag: &u64, val: &Box<CborType>) {
+fn encode_tag(output: &mut Vec<u8>, tag: &u64, val: &CborType) {
     common_encode_unsigned(output, 6, *tag);
     output.append(&mut val.serialize());
 }
@@ -103,14 +103,14 @@ impl CborType {
     /// Serialize a Cbor object.
     pub fn serialize(&self) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::new();
-        match self {
-            &CborType::Integer(ref unsigned) => encode_unsigned(&mut bytes, *unsigned),
-            &CborType::SignedInteger(ref negative) => encode_negative(&mut bytes, *negative),
-            &CborType::Bytes(ref bstr) => encode_bytes(&mut bytes, &bstr),
-            &CborType::String(ref tstr) => encode_string(&mut bytes, &tstr),
-            &CborType::Array(ref arr) => encode_array(&mut bytes, &arr),
-            &CborType::Map(ref map) => encode_map(&mut bytes, &map),
-            &CborType::Tag(ref t, ref val) => encode_tag(&mut bytes, t, val),
+        match *self {
+            CborType::Integer(ref unsigned) => encode_unsigned(&mut bytes, *unsigned),
+            CborType::SignedInteger(ref negative) => encode_negative(&mut bytes, *negative),
+            CborType::Bytes(ref bstr) => encode_bytes(&mut bytes, bstr),
+            CborType::String(ref tstr) => encode_string(&mut bytes, tstr),
+            CborType::Array(ref arr) => encode_array(&mut bytes, arr),
+            CborType::Map(ref map) => encode_map(&mut bytes, map),
+            CborType::Tag(ref t, ref val) => encode_tag(&mut bytes, t, val),
         };
         bytes
     }

--- a/src/cose/cose.rs
+++ b/src/cose/cose.rs
@@ -1,4 +1,4 @@
-//! This module implements COSE using the cose::decoder and cose::nss bindings.
+//! This module implements COSE using the `cose::decoder` and `cose::nss` bindings.
 
 use cose::nss;
 use cose::decoder::*;
@@ -24,8 +24,8 @@ pub fn verify_signature(payload: &[u8], cose_signature: Vec<u8>) -> Result<(), C
         return Err(CoseError::LibraryFailure);
     }
     let signature_type = &cose_signatures[0].signature_type;
-    let signature_algorithm = match signature_type {
-        &CoseSignatureType::ES256 => nss::SignatureAlgorithm::ES256,
+    let signature_algorithm = match *signature_type {
+        CoseSignatureType::ES256 => nss::SignatureAlgorithm::ES256,
         _ => return Err(CoseError::LibraryFailure),
     };
     let signature_bytes = &cose_signatures[0].signature;
@@ -33,7 +33,7 @@ pub fn verify_signature(payload: &[u8], cose_signature: Vec<u8>) -> Result<(), C
 
     // Verify the parsed signature.
     let verify_result = nss::verify_signature(
-        signature_algorithm,
+        &signature_algorithm,
         &cose_signatures[0].signer_cert,
         real_payload,
         signature_bytes,
@@ -44,7 +44,7 @@ pub fn verify_signature(payload: &[u8], cose_signature: Vec<u8>) -> Result<(), C
     Ok(())
 }
 
-/// Sign the payload and return a serialised COSE_Sign object.
+/// Sign the payload and return a serialised `COSE_Sign` object.
 #[allow(unused_variables)]
 pub fn sign(payload: &[u8]) -> Result<Vec<u8>, CoseError> {
     unimplemented!()

--- a/src/cose/decoder.rs
+++ b/src/cose/decoder.rs
@@ -23,8 +23,8 @@ pub struct CoseSignature {
 
 macro_rules! unpack {
    ($to:tt, $var:ident) => (
-        match $var {
-            &CborType::$to(ref cbor_object) => {
+        match *$var {
+            CborType::$to(ref cbor_object) => {
                 cbor_object
             }
             _ => return Err(CoseError::UnexpectedType),
@@ -33,8 +33,8 @@ macro_rules! unpack {
 }
 
 fn get_map_value(map: &CborType, key: &CborType) -> Result<CborType, CoseError> {
-    match map {
-        &CborType::Map(ref values) => {
+    match *map {
+        CborType::Map(ref values) => {
             match values.get(key) {
                 Some(x) => Ok(x.clone()),
                 _ => Err(CoseError::MissingHeader),
@@ -44,42 +44,42 @@ fn get_map_value(map: &CborType, key: &CborType) -> Result<CborType, CoseError> 
     }
 }
 
-/// COSE_Sign = [
+/// `COSE_Sign` = [
 ///     Headers,
 ///     payload : bstr / nil,
-///     signatures : [+ COSE_Signature]
+///     signatures : [+ `COSE_Signature`]
 /// ]
 ///
 /// Headers = (
-///     protected : empty_or_serialized_map,
-///     unprotected : header_map
+///     protected : `empty_or_serialized_map`,
+///     unprotected : `header_map`
 /// )
 ///
 /// This syntax is a little unintuitive. Taken together, the two previous definitions essentially
 /// mean:
 ///
-/// COSE_Sign = [
-///     protected : empty_or_serialized_map,
-///     unprotected : header_map
+/// `COSE_Sign` = [
+///     protected : `empty_or_serialized_map`,
+///     unprotected : `header_map`
 ///     payload : bstr / nil,
-///     signatures : [+ COSE_Signature]
+///     signatures : [+ `COSE_Signature`]
 /// ]
 ///
-/// (COSE_Sign is an array. The first element is an empty or serialized map (in our case, it is
+/// (`COSE_Sign` is an array. The first element is an empty or serialized map (in our case, it is
 /// never expected to be empty). The second element is a map (it is expected to be empty. The third
 /// element is a bstr or nil (it is expected to be nil). The fourth element is an array of
-/// COSE_Signature.)
+/// `COSE_Signature`.)
 ///
-/// COSE_Signature =  [
+/// `COSE_Signature` =  [
 ///     Headers,
 ///     signature : bstr
 /// ]
 ///
 /// but again, unpacking this:
 ///
-/// COSE_Signature =  [
-///     protected : empty_or_serialized_map,
-///     unprotected : header_map
+/// `COSE_Signature` =  [
+///     protected : `empty_or_serialized_map`,
+///     unprotected : `header_map`
 ///     signature : bstr
 /// ]
 

--- a/src/cose/test_nss_sign.rs
+++ b/src/cose/test_nss_sign.rs
@@ -22,14 +22,14 @@ fn test_rfc6979_test_vector_1() {
     let payload = b"sample";
 
     // Sign.
-    let signature_result = nss::sign(nss::SignatureAlgorithm::ES256, NIST_P256_TEST_PK8, payload);
+    let signature_result = nss::sign(&nss::SignatureAlgorithm::ES256, NIST_P256_TEST_PK8, payload);
     assert!(signature_result.is_ok());
     let signature_result = signature_result.unwrap();
 
     // Verify the signature.
     assert!(
         nss::verify_signature(
-            nss::SignatureAlgorithm::ES256,
+            &nss::SignatureAlgorithm::ES256,
             test::NIST_P256_TEST_SPKI,
             payload,
             &signature_result,

--- a/src/cose/test_nss_verify.rs
+++ b/src/cose/test_nss_verify.rs
@@ -20,7 +20,7 @@ fn test_rfc6979_test_vector_1() {
     let payload = b"sample";
     assert!(
         nss::verify_signature(
-            nss::SignatureAlgorithm::ES256,
+            &nss::SignatureAlgorithm::ES256,
             test::NIST_P256_TEST_SPKI,
             payload,
             &signature,
@@ -45,7 +45,7 @@ fn test_rfc6979_test_vector_2() {
     let payload = b"test";
     assert!(
         nss::verify_signature(
-            nss::SignatureAlgorithm::ES256,
+            &nss::SignatureAlgorithm::ES256,
             test::NIST_P256_TEST_SPKI,
             payload,
             &signature,
@@ -72,7 +72,7 @@ fn test_tampered_signature_es256() {
     let payload = b"test";
     assert!(
         nss::verify_signature(
-            nss::SignatureAlgorithm::ES256,
+            &nss::SignatureAlgorithm::ES256,
             test::NIST_P256_TEST_SPKI,
             payload,
             &signature,
@@ -98,7 +98,7 @@ fn test_tampered_message_es256() {
     let payload = b"testTAMPERED";
     assert!(
         nss::verify_signature(
-            nss::SignatureAlgorithm::ES256,
+            &nss::SignatureAlgorithm::ES256,
             test::NIST_P256_TEST_SPKI,
             payload,
             &signature,
@@ -209,7 +209,7 @@ fn test_fips186_3_test_vector_1() {
                        0xdc, 0x3d, 0x11, 0x1d, 0x0f, 0xeb, 0x70, 0x06];
     assert!(
         nss::verify_signature(
-            nss::SignatureAlgorithm::PS256,
+            &nss::SignatureAlgorithm::PS256,
             FIPS_RSA_3072_SPKI,
             &payload,
             &signature,

--- a/src/cose/test_setup.rs
+++ b/src/cose/test_setup.rs
@@ -15,7 +15,7 @@ pub fn setup() {
     START.call_once(|| {
         let null_ptr: *const u8 = ptr::null();
         unsafe {
-            assert!(NSS_NoDB_Init(null_ptr) == SEC_SUCCESS);
+            assert_eq!(NSS_NoDB_Init(null_ptr), SEC_SUCCESS);
         }
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
 #[macro_use(defer)]
 extern crate scopeguard;
 


### PR DESCRIPTION
This fixes most clippy warnings.
We need better naming to make the last two go away.

(Includes changes from #24)