### PR TITLE
replace obsoleted symbol ONCE_INIT

### DIFF
--- a/examples/sign_verify/test_setup.rs
+++ b/examples/sign_verify/test_setup.rs
@@ -1,7 +1,7 @@
 use std::os::raw;
 use std::ptr;
-use std::sync::{ONCE_INIT, Once};
-static START: Once = ONCE_INIT;
+use std::sync::Once;
+static START: Once = Once::new();
 
 type SECStatus = raw::c_int;
 const SEC_SUCCESS: SECStatus = 0;


### PR DESCRIPTION
rust's std::sync::Once library has obsoleted the ONCE_INIT symbol, and this patch replaces it with Once::new().
