### PR TITLE
add cargo fuzz decode_signature target

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "cose-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.cose]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_decode_signature"
+path = "fuzz_targets/fuzz_decode_signature.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_decode_signature.rs
+++ b/fuzz/fuzz_targets/fuzz_decode_signature.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+extern crate cose;
+
+fuzz_target!(|signature_bytes: &[u8]| {
+    let _ = cose::decoder::decode_signature(signature_bytes, &[]);
+});


### PR DESCRIPTION
Add boilerplate from the cargo-fuzz tutorial for #16. Example usage:

```console
» cargo +nightly fuzz run -s address fuzz_decode_signature
    Finished release [optimized] target(s) in 0.01s
    Finished release [optimized] target(s) in 0.01s
     Running `target/x86_64-unknown-linux-gnu/release/fuzz_decode_signature -artifact_prefix=/home/gguthe/cose-rust/fuzz/artifacts/fuzz_decode_signature/ /home/gguthe/cose-rust/fuzz/corpus/fuzz_decode_signature`
INFO: Seed: 286269949
INFO: Loaded 1 modules   (4274 inline 8-bit counters): 4274 [0x55ff672bdd29, 0x55ff672beddb), 
INFO: Loaded 1 PC tables (4274 PCs): 4274 [0x55ff672bede0,0x55ff672cf900), 
INFO:      984 files found in /home/gguthe/cose-rust/fuzz/corpus/fuzz_decode_signature
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 984 min: 1b max: 742b total: 78573b rss: 32Mb
#985    INITED cov: 299 ft: 1959 corp: 618/36Kb exec/s: 0 rss: 103Mb
#1086   REDUCE cov: 299 ft: 1959 corp: 618/36Kb lim: 751 exec/s: 0 rss: 106Mb L: 623/742 MS: 1 EraseBytes-
#1543   REDUCE cov: 299 ft: 1959 corp: 618/36Kb lim: 751 exec/s: 0 rss: 116Mb L: 69/742 MS: 2 EraseBytes-CopyPart-
#3959   REDUCE cov: 299 ft: 1959 corp: 618/36Kb lim: 769 exec/s: 3959 rss: 184Mb L: 265/742 MS: 1 EraseBytes-
#4721   REDUCE cov: 299 ft: 1959 corp: 618/36Kb lim: 769 exec/s: 4721 rss: 202Mb L: 157/742 MS: 2 ChangeBit-EraseBytes-
^C==566876== libFuzzer: run interrupted; exiting
```