### PR TITLE
Remove trailing semicolons in expression macro bodies to fix future-incompat

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -33,7 +33,7 @@ macro_rules! unpack {
                 cbor_object
             }
             _ => return Err(CoseError::UnexpectedType),
-        };
+        }
     )
 }
 


### PR DESCRIPTION
See also: https://github.com/rust-lang/rust/issues/79813

I followed a warning while compiling firefox:

```
 6:46.04 warning: the following packages contain code that will be rejected by a future version of Rust: cose v0.1.4
 6:46.56 note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

The report looks like this:

```
> cargo report future-incompatibilities --id 1
The following warnings were discovered during the build. These warnings are an
indication that the packages contain code that will become an error in a
future release of Rust. These warnings typically cover changes to close
soundness problems, unintended or undocumented behavior, or critical problems
that cannot be fixed in a backwards-compatible fashion, and are not expected
to be in wide use.

Each warning should contain a link for more information on what the warning
means and how to resolve it.

To solve this problem, you can try the following approaches:

- If the issue is not solved by updating the dependencies, a fix has to be
implemented by those dependencies. You can help with that by notifying the
maintainers of this problem (e.g. by creating a bug report) or by proposing a
fix to the maintainers (e.g. by creating a pull request):

  - cose@0.1.4
  - Repository: https://github.com/franziskuskiefer/cose-rust
  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package cose@0.1.4`

- If waiting for an upstream fix is not an option, you can use the `[patch]`
section in `Cargo.toml` to use your own version of the dependency. For more
information, see:
https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section

The package `cose v0.1.4 (/home/user/tmp/cose-rust)` currently triggers the following future incompatibility lints:
> warning: trailing semicolon in macro used in expression position
>   --> src/decoder.rs:36:10
>    |
> 36 |         };
>    |          ^
> ...
> 52 |     let unpacked = unpack!(Map, map);
>    |                    ----------------- in this macro invocation
>    |
>    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>    = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
>    = note: this warning originates in the macro `unpack` (in Nightly builds, run with -Z macro-backtrace for more info)
[...]
```